### PR TITLE
give version number as string to avoid AttributeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='yoink',
-    version=0.2,
+    version='0.2',
     description='Yoinking data from rasterized images',
     author='Matt Terry',
     author_email='matt.terry@gmail.com',


### PR DESCRIPTION
AttributeError: 'float' object has no attribute 'startswith'
