### PR TITLE
AxesWidget wasn't available in matplotlib 1.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='yoink',
@@ -8,5 +8,5 @@ setup(
     author_email='matt.terry@gmail.com',
     url='https://github.com/mrterry/yoink',
     packages=['yoink'],
-    install_requires=['numpy', 'scipy', 'skimage'],
+    install_requires=['numpy', 'scipy', 'skimage', 'matplotlib >= 1.2'],
 )


### PR DESCRIPTION
not sure if this fixes the issue ...

use setuptools because of 

http://stackoverflow.com/questions/9810603/adding-install-requires-to-setup-py-when-making-a-python-package
